### PR TITLE
fix: build warning

### DIFF
--- a/hal/hal_hci/hal_usb.c
+++ b/hal/hal_hci/hal_usb.c
@@ -26,7 +26,7 @@ int	usb_init_recv_priv(_adapter *padapter, u16 ini_in_buf_sz)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&precvpriv->recv_tasklet,
-		     (void(*)(unsigned long))usb_recv_tasklet,
+		     (void(*))usb_recv_tasklet,
 		     (unsigned long)padapter);
 #endif /* PLATFORM_LINUX */
 

--- a/hal/rtl8821c/usb/rtl8821cu_xmit.c
+++ b/hal/rtl8821c/usb/rtl8821cu_xmit.c
@@ -931,7 +931,7 @@ s32	rtl8821cu_init_xmit_priv(PADAPTER padapter)
 
 #ifdef PLATFORM_LINUX
 	tasklet_init(&pxmitpriv->xmit_tasklet,
-		     (void(*)(unsigned long))rtl8821cu_xmit_tasklet,
+		     (void(*))rtl8821cu_xmit_tasklet,
 		     (unsigned long)padapter);
 #endif
 #ifdef CONFIG_TX_EARLY_MODE


### PR DESCRIPTION
  warning: cast between incompatible function types from ‘void (*)(void *)’ to ‘void (*)(long unsigned int)’
  The void* type has been used, no need to convert to long unsigned type