### PR TITLE
Fix GCC misleading-indentation error

### DIFF
--- a/core/efuse/rtw_efuse.c
+++ b/core/efuse/rtw_efuse.c
@@ -940,11 +940,11 @@ void rtw_efuse_analyze(PADAPTER	padapter, u8 Type, u8 Fake)
 	for (i = 0; i < mapLen; i++) {
 		if (i % 16 == 0)
 			RTW_PRINT_SEL(RTW_DBGDUMP, "0x%03x: ", i);
-			_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
-				, pEfuseHal->fakeEfuseInitMap[i]
-				, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
-			);
-		}
+		_RTW_PRINT_SEL(RTW_DBGDUMP, "%02X%s"
+			, pEfuseHal->fakeEfuseInitMap[i]
+			, ((i + 1) % 16 == 0) ? "\n" : (((i + 1) % 8 == 0) ? "	  " : " ")
+		);
+	}
 	_RTW_PRINT_SEL(RTW_DBGDUMP, "\n");
 
 out_free_buffer:

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -3639,11 +3639,11 @@ int validate_mp_recv_frame(_adapter *adapter, union recv_frame *precv_frame)
 			for (i = 0; i < precv_frame->u.hdr.len; i = i + 8)
 				RTW_INFO("%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X:\n", *(ptr + i),
 					*(ptr + i + 1), *(ptr + i + 2) , *(ptr + i + 3) , *(ptr + i + 4), *(ptr + i + 5), *(ptr + i + 6), *(ptr + i + 7));
-				RTW_INFO("#############################\n");
-				_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
-				_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
-				pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
-				pmppriv->mplink_brx =_TRUE;
+			RTW_INFO("#############################\n");
+			_rtw_memset(pmppriv->mplink_buf, '\0' , sizeof(pmppriv->mplink_buf));
+			_rtw_memcpy(pmppriv->mplink_buf, ptr, precv_frame->u.hdr.len);
+			pmppriv->mplink_rx_len = precv_frame->u.hdr.len;
+			pmppriv->mplink_brx =_TRUE;
 		}
 	}
 	if (pmppriv->bloopback) {


### PR DESCRIPTION
Since upgrading to Linux v5.18 in Nixpkgs, we've been seeing errors
from GCC about this confusing indentation.

Signed-off-by: Alyssa Ross <hi@alyssa.is>
