### PR TITLE
Update arch required packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ sudo xbps-install linux-headers dkms git make
 If using pacman
 
 ```
-sudo pacman -S --noconfirm linux-headers dkms git
+sudo pacman -S --noconfirm linux-headers dkms git bc
 ```
 
 Note: If you are asked to choose a provider, make sure to choose the one


### PR DESCRIPTION
When installing the driver I was asked to install bc, since I got the message "bc: command not found", on multiple installations of arch. I think this should be included in the README.