### PR TITLE
readme: add link to skiffos tested distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ the Installation Steps can be improved.
 
 - Raspberry Pi Desktop (2022-07-01) (x86 32 bit) (kernel 5.10)
 
+- SkiffOS for Odroid XU4 (ARM 32 bit) (kernel 6.0.7)
+
 - Ubuntu 22.04 (kernel 5.15) and 22.10 (kernel 5.19)
 
 - Void Linux (kernel 5.18)
@@ -101,6 +103,7 @@ the Installation Steps can be improved.
 - [Manjaro](https://manjaro.org)
 - [openSUSE](https://www.opensuse.org/)
 - [Raspberry Pi OS](https://www.raspberrypi.org)
+- [SkiffOS](https://github.com/skiffos/skiffos/)
 - [Ubuntu](https://www.ubuntu.com)
 - [Void Linux](https://voidlinux.org/)
 


### PR DESCRIPTION
Adding SkiffOS as a tested distribution. rtl8821cu is now enabled on default.

https://github.com/skiffos/SkiffOS/commit/76a3021a2937dbbcf561410ba13990e7a3e1aa5d#diff-3b59d3f8cb158a68b0be78027d2fdbd3b6dfd2449c4a8ef22a648e4c5917666cR21