### PR TITLE
Change install script to rely on EDITOR variable not hardcoded to nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ dtoverlay=disable-wifi
 #### Step 1: Edit wpa_supplicant.conf
 
 ```
-sudo nano /etc/wpa_supplicant/wpa_supplicant.conf
+sudo ${EDITOR} /etc/wpa_supplicant/wpa_supplicant.conf
 ```
 
 #### Step 2: Delete the relevant WiFi network block (including the 'network=' and opening/closing braces.

--- a/docs/Concurrent_Mode.md
+++ b/docs/Concurrent_Mode.md
@@ -29,7 +29,7 @@ How do I Enable Concurrent Mode?
 Edit the `Makefile` with a text editor:
 
 ```
-nano Makefile
+${EDITOR} Makefile
 ```
 
 Change the following line:

--- a/edit-options.sh
+++ b/edit-options.sh
@@ -20,7 +20,7 @@ then
 	exit 1
 fi
 
-nano /etc/modprobe.d/${OPTIONS_FILE}
+${EDITOR} /etc/modprobe.d/${OPTIONS_FILE}
 
 read -p "Do you want to apply the new options by rebooting now? [y/N] " -n 1 -r
 echo    # move to a new line

--- a/edit-options.sh
+++ b/edit-options.sh
@@ -20,6 +20,19 @@ then
 	exit 1
 fi
 
+# Check if ${EDITOR} is an executable or try to default to nano or finally complain if it's not installed.
+if ! [ -x "${EDITOR}" ]
+then
+	EDITOR="$(which nano 2>/dev/null)"
+	if ! [ -x "${EDITOR}" ]
+	then
+		echo "No text editor found (default: nano)."
+		echo "Please install one and set the EDITOR variable to point to it."
+		echo "When you have an editor, please run \"sudo ./${SCRIPT_NAME}\""
+		exit 1
+	fi
+fi
+
 ${EDITOR} /etc/modprobe.d/${OPTIONS_FILE}
 
 read -p "Do you want to apply the new options by rebooting now? [y/N] " -n 1 -r

--- a/install-driver.sh
+++ b/install-driver.sh
@@ -86,13 +86,17 @@ then
 	exit 1
 fi
 
-# check to ensure ${EDITOR} is defined correctly
+# Check if ${EDITOR} is an executable or try to default to nano or finally complain if it's not installed.
 if ! [ -x "${EDITOR}" ]
 then
-	echo "The EDITOR variable is not defined or doesn't refer to an executable."
-	echo "Please set and export EDITOR to the path of your preferred text editor"
-	echo "Once set, please rerun \"sudo ./${SCRIPT_NAME}\""
-	exit 1
+	EDITOR="$(which nano 2>/dev/null)"
+	if ! [ -x "${EDITOR}" ]
+	then
+		echo "No text editor found (default: nano)."
+		echo "Please install one and set the EDITOR variable to point to it."
+		echo "When you have an editor, please run \"sudo ./${SCRIPT_NAME}\""
+		exit 1
+	fi
 fi
 
 # support for the NoPrompt option allows non-interactive use of this script

--- a/install-driver.sh
+++ b/install-driver.sh
@@ -86,12 +86,12 @@ then
 	exit 1
 fi
 
-# check to ensure nano is installed
-if ! command -v nano >/dev/null 2>&1
+# check to ensure ${EDITOR} is defined correctly
+if ! [ -x "${EDITOR}" ]
 then
-	echo "A required package is not installed."
-	echo "Please install the following package: nano"
-	echo "Once the package is installed, please run \"sudo ./${SCRIPT_NAME}\""
+	echo "The EDITOR variable is not defined or doesn't refer to an executable."
+	echo "Please set and export EDITOR to the path of your preferred text editor"
+	echo "Once set, please rerun \"sudo ./${SCRIPT_NAME}\""
 	exit 1
 fi
 
@@ -313,7 +313,7 @@ then
 	echo
 	if [[ $REPLY =~ ^[Yy]$ ]]
 	then
-		nano /etc/modprobe.d/${OPTIONS_FILE}
+		${EDITOR} /etc/modprobe.d/${OPTIONS_FILE}
 	fi
 
 	read -p "Do you want to reboot now? (recommended) [y/N] " -n 1 -r


### PR DESCRIPTION
My default install doesn't have nano in it and it's not _my_ preferred editor.
I figured it's better to rely on the standard `${EDITOR}` environment variable to let the user have their own preferred editor.