### PR TITLE
Don't set CONFIG_RTW_SW_LED again if it's already set

### DIFF
--- a/include/autoconf.h
+++ b/include/autoconf.h
@@ -167,7 +167,9 @@
 
 #define CONFIG_RTW_LED
 #ifdef CONFIG_RTW_LED
+#ifndef CONFIG_RTW_SW_LED
 	#define CONFIG_RTW_SW_LED
+#endif	
 	#ifdef CONFIG_RTW_SW_LED
 		/* #define CONFIG_RTW_LED_HANDLED_BY_CMD_THREAD */
 	#endif


### PR DESCRIPTION
Really minor fix. If CONFIG_RTW_SW_LED is already set, then every file generated a compiler warning about it being defined again. I wrapped it in an ifndef so it won't give the warning.

Thanks for such a great driver!